### PR TITLE
Add a new command to display buffer info

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ find our blog post about this very first experience:
 
     ```
     $ msw
-    usage: ModernScienceWeekly [--version] [--help] <command> [<args>]
+    usage: msw [--version] [--help] <command> [<args>]
 
     Available commands are:
-        buffer      push links to Buffer.com's queue
+        buffer
         generate    generate HTML for Tinyletter from a YAML file
         new         create a new empty YAML file to prepare a new issue
         validate    check that an issue is valid

--- a/command/buffer_info.go
+++ b/command/buffer_info.go
@@ -1,0 +1,80 @@
+package command
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/TailorDev/msw/buffer"
+	"github.com/TailorDev/msw/config"
+	"github.com/mitchellh/cli"
+)
+
+// BufferInfoCommand is a Command that outputs Buffer.com information.
+type BufferInfoCommand struct {
+	UI cli.Ui
+}
+
+// Run runs the code of the comand.
+func (c *BufferInfoCommand) Run(args []string) int {
+	cmdFlags := flag.NewFlagSet("buffer-info", flag.ContinueOnError)
+	cmdFlags.Usage = func() { c.UI.Output(c.Help()) }
+	if err := cmdFlags.Parse(args); err != nil {
+		return 1
+	}
+
+	conf, err := config.LoadDefaultConfig()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("%s", err))
+		return 1
+	}
+
+	if conf.Buffer.AccessToken == "" {
+		c.UI.Error("You must specify an access token in the configuration file.")
+		return 1
+	}
+
+	if len(conf.Buffer.ProfileIDs) == 0 {
+		c.UI.Error("You must specify at least one profile ID in the configuration file.")
+		return 1
+	}
+
+	cli := buffer.NewClient(conf.Buffer.AccessToken)
+	for _, id := range conf.Buffer.ProfileIDs {
+		p, err := cli.GetProfile(id)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("%s", err))
+			continue
+		}
+
+		c.UI.Output(fmt.Sprintf("\nProfile: %s (%s)", p.FormattedUsername, p.Service))
+
+		updates, _ := cli.GetPendingUpdates(id)
+
+		c.UI.Output(fmt.Sprintf("Buffer : %d / %d\n", len(updates), conf.Buffer.BufferSize))
+		c.UI.Output("Scheduled updates:\n")
+
+		for _, u := range updates {
+			c.UI.Output(fmt.Sprintf("%-25s: %s", u.Day, u.Text))
+		}
+	}
+
+	return 0
+}
+
+// Help returns the description of the command.
+func (*BufferInfoCommand) Help() string {
+	helpText := `
+Usage: msw buffer info
+
+  This command shows information about Buffer.com. You need a configuration
+  file with Buffer credentials ('~/.msw/msw.yml').
+
+`
+	return strings.TrimSpace(helpText)
+}
+
+// Synopsis returns the short description of the command.
+func (*BufferInfoCommand) Synopsis() string {
+	return "output Buffer.com information"
+}

--- a/command/buffer_push.go
+++ b/command/buffer_push.go
@@ -11,17 +11,17 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-// BufferCommand is a Command that pushes links to Buffer.com's queue.
-type BufferCommand struct {
+// BufferPushCommand is a Command that pushes links to Buffer.com's queue.
+type BufferPushCommand struct {
 	UI cli.Ui
 }
 
 // Run runs the code of the comand.
-func (c *BufferCommand) Run(args []string) int {
-	var push bool
-	cmdFlags := flag.NewFlagSet("buffer", flag.ContinueOnError)
+func (c *BufferPushCommand) Run(args []string) int {
+	var apply bool
+	cmdFlags := flag.NewFlagSet("buffer push", flag.ContinueOnError)
 	cmdFlags.Usage = func() { c.UI.Output(c.Help()) }
-	cmdFlags.BoolVar(&push, "push", false, "")
+	cmdFlags.BoolVar(&apply, "apply", false, "")
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
 	}
@@ -54,8 +54,8 @@ func (c *BufferCommand) Run(args []string) int {
 		return 1
 	}
 
-	if !push {
-		c.UI.Output("Re-run the command with `-push` to actually push to Buffer.com\n")
+	if !apply {
+		c.UI.Output("Re-run the command with `-apply` to actually push to Buffer.com\n")
 	}
 
 	cli := buffer.NewClient(conf.Buffer.AccessToken)
@@ -64,7 +64,7 @@ func (c *BufferCommand) Run(args []string) int {
 			if link.Name != "" && link.URL != "" {
 				text := link.GetBufferText()
 
-				if push {
+				if apply {
 					updates, err := cli.Push(text, conf.Buffer.ProfileIDs)
 					if err != nil {
 						c.UI.Error(fmt.Sprintf("%s", err))
@@ -85,22 +85,22 @@ func (c *BufferCommand) Run(args []string) int {
 }
 
 // Help returns the description of the command.
-func (*BufferCommand) Help() string {
+func (*BufferPushCommand) Help() string {
 	helpText := `
-Usage: msw buffer [options] FILENAME
+Usage: msw buffer push [options] FILENAME
 
   This command pushes each entry of an issue to Buffer.com's queue. You need
   a configuration file with Buffer credentials ('~/.msw/msw.yml').
 
 Options:
 
-  -push				Push to Buffer.com's queue.
+  -apply				Push to Buffer.com's queue.
 
 `
 	return strings.TrimSpace(helpText)
 }
 
 // Synopsis returns the short description of the command.
-func (*BufferCommand) Synopsis() string {
+func (*BufferPushCommand) Synopsis() string {
 	return "push links to Buffer.com's queue"
 }

--- a/config/config.go
+++ b/config/config.go
@@ -19,10 +19,13 @@ type Config struct {
 type BufferOptions struct {
 	AccessToken string
 	ProfileIDs  []string
+	BufferSize  int
 }
 
 var DefaultConfig = Config{
-	Buffer: BufferOptions{},
+	Buffer: BufferOptions{
+		BufferSize: 10,
+	},
 }
 
 var configDirName = "msw"

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 		ErrorWriter: os.Stderr,
 	}
 
-	c := cli.NewCLI("ModernScienceWeekly", version.FormattedVersion())
+	c := cli.NewCLI("msw", version.FormattedVersion())
 	c.Args = os.Args[1:]
 
 	c.Commands = map[string]cli.CommandFactory{
@@ -30,8 +30,11 @@ func main() {
 		"validate": func() (cli.Command, error) {
 			return &command.ValidateCommand{UI: ui}, nil
 		},
-		"buffer": func() (cli.Command, error) {
-			return &command.BufferCommand{UI: ui}, nil
+		"buffer push": func() (cli.Command, error) {
+			return &command.BufferPushCommand{UI: ui}, nil
+		},
+		"buffer info": func() (cli.Command, error) {
+			return &command.BufferInfoCommand{UI: ui}, nil
 		},
 	}
 


### PR DESCRIPTION
Example:

```
$ msw buffer info

Profile: @ModScienceWkly (twitter)
Buffer : 8 / 10

Scheduled updates:

Today                    : A post-publication peer review success story: http://blog.scienceopen.com/2017/02/a-post-publication-peer-review-success-story/.
Tomorrow                 : Peer-review activists push psychology journals towards #opendata: http://www.nature.com/news/peer-review-activists-push-psychology-journals-towards-open-data-1.21549.
Monday 3rd April         : #Jupyter Notebooks and reproducible data science: https://markwoodbridge.com/2017/03/05/jupyter-reproducible-science.html.
Tuesday 4th April        : Breaking the Ice and Forging Links: The Importance of Socializing in Research – http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003355.
Wednesday 5th April      : The gulf between the open science movement and academics: https://www.software.ac.uk/blog/2017-03-09-gulf-between-open-science-movement-and-academics.
Thursday 6th April       : #Open mind, #openscience: http://onsnetwork.org/chartgerink/2017/03/09/open-mind-open-science-speech-for-tilburg-uni-board/.
Friday 7th April         : Reproducible analysis through automated #Jupyter Notebook pipelines: http://compbio.ucsd.edu/reproducible-analysis-automated-jupyter-notebook-pipelines/.
Monday 10th April        : Why Teaching Makes You Smarter: http://blogs.plos.org/thestudentblog/2017/01/27/why-teaching-makes-you-smarter/.
```